### PR TITLE
⬆️ HTTP 1.0 --> HTTP 1.1

### DIFF
--- a/browser.py
+++ b/browser.py
@@ -93,7 +93,7 @@ class URL:
             ("User-Agent", "ej-browser"),
             ("Accept-Encoding", "gzip")
         ]
-        request = f"GET {self.path} HTTP/1.0\r\n"
+        request = f"GET {self.path} HTTP/1.1\r\n"
         for (header, value) in request_headers:
             request += f"{header}: {value}\r\n"
         request += "\r\n"


### PR DESCRIPTION
Guten Shabbes King,
I was trying to understand why my code runs into error on Exercise 1.9, and was looking at your code for ✨inspiration✨

I found a nitpick at yours, exercise 1.1 says to change HTTP 1.0 to HTTP 1.1, and now both the "content-encoding" and "transfer-encoding" headers are being sent to you, WITHOUT the "content-length" header for whatever reason.
(there's also a change at the etag header)

**_NOTICE_** - the code won't work now

(And yes, I opened a pull request instead of an issue because I wanted to try it out. Bite me.)